### PR TITLE
Fix for issue #13920, changed behavior od Start from hour introduced in 5.1

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -234,15 +234,6 @@ class Interval implements ScheduleModeInterface
         $groupExecutionDate = $this->getGroupExecutionDateWithTimeZone($contact, $eventId, $compareFromDateTime);
         $groupExecutionDate->setTime((int) $groupExecutionDate->format('H'), (int) $groupExecutionDate->format('i'));
 
-        $testGroupHour = clone $groupExecutionDate;
-        $testGroupHour->setTime($groupHour->format('H'), $groupHour->format('i'));
-
-        if ($groupExecutionDate <= $testGroupHour) {
-            return $testGroupHour;
-        } else {
-            $groupExecutionDate->modify('+1 day')->setTime($groupHour->format('H'), $groupHour->format('i'));
-        }
-
         return $groupExecutionDate;
     }
 


### PR DESCRIPTION
Changes introduced in 5.1 (894929c) brakes the functionality of executing campaigns when set "Start from hour". This push request brings this back to previous behavior. When you set Start from specific hour was in 5.1: if it is earlier then it's planned for a specific hour and fired up correctly BUT when it is later then it's scheduled for the selected hour BUT for NEXT day. Now it works as before. When it is earlier than it's planned for a specific hour and fired up correctly AND when it is later, then it fires immediately.